### PR TITLE
Support dragging of SVG elements

### DIFF
--- a/lib/src/dnd/draggable_emulated.dart
+++ b/lib/src/dnd/draggable_emulated.dart
@@ -56,7 +56,7 @@ List<StreamSubscription> _installEmulatedDraggable(Element element, DraggableGro
     if (_emulDragHandled || downEvent.button != 0 || !_isValidDragStartTarget(
             element, downEvent.target, group.handle, group.cancel)) 
       return;
-    
+      
     // Text selections should not be a problem with emulated draggable, but it
     // seems better usability to remove text selection when dragging something.
     html5.clearTextSelections();
@@ -296,7 +296,7 @@ void _restoreCursor() {
 EventTarget _getRealTarget(EventTarget target, Point mouseClientPosition) {
   EventTarget realTarget = target;
   
-  if (_emulDragImage.element == target || _emulDragImage.element.contains(target)) {
+  if (_emulDragImage.element == target || _emulDragImage._contains(target)) {
     // Forward events on the drag image to element underneath.
     _emulDragImage.element.style.visibility = 'hidden';
     realTarget = document.elementFromPoint(mouseClientPosition.x, 

--- a/lib/src/dnd/dropzone.dart
+++ b/lib/src/dnd/dropzone.dart
@@ -76,17 +76,12 @@ class DropzoneGroup extends Group {
     
     List<StreamSubscription> subs = new List<StreamSubscription>();
     
-    // Install as HTML5 dropzone for all browsers except IE9.
-    if (html5.supportsDraggable) {
-      _logger.finest('installing as dropzone');
-      subs.addAll(_installDropzone(element, this));
-    }
-    
-    // Install as emulated dropzone for IE9, IE10 and if touch is used.
-    if (!html5.supportsSetDragImage || _useTouchEvents()) {
-      _logger.finest('installing as emulated dropzone');
-      subs.addAll(_installEmulatedDropzone(element, this));
-    }
+    // Install both native and emulated dropzones. This is to support 
+    // dropping of SVG elements.
+    _logger.finest('installing as dropzone');
+    _logger.finest('installing as emulated dropzone');
+    subs.addAll(_installDropzone(element, this));
+    subs.addAll(_installEmulatedDropzone(element, this));
     
     installedElements[element].addAll(subs);
   }

--- a/test/svg/svg.css
+++ b/test/svg/svg.css
@@ -1,0 +1,10 @@
+.dropzone {
+  width: 200px;
+  height: 100px;
+  background-color: grey;
+}
+
+.dnd-over {
+  background-color: green;
+  fill: green;
+}

--- a/test/svg/svg_test.dart
+++ b/test/svg/svg_test.dart
@@ -1,0 +1,43 @@
+/**
+ * Test for SVG elements.
+ */
+library svt_test;
+
+import 'dart:html';
+import 'dart:svg' as svg;
+
+import 'package:logging_handlers/logging_handlers_shared.dart';
+import 'package:logging/logging.dart';
+import 'package:html5_dnd/html5_dnd.dart';
+
+final _logger = new Logger("complex_elements_test");
+
+main() {
+  Logger.root.onRecord.listen(new PrintHandler().call);
+  Logger.root.level = Level.FINEST;
+  
+  installDragAndDrop();
+}
+
+void installDragAndDrop() {
+  var svgDrag = new DraggableGroup(
+      dragImageFunction: (Element draggable) {
+        var element = new svg.SvgElement.tag('svg')
+            ..attributes = {
+                            'width': '100',
+                            'height': '100'
+            }
+            ..append(draggable.clone(true));
+        return new DragImage(element, 0, 0);
+      }
+  );
+  svgDrag.install(query("#svgRect"));
+  
+  var divDrag = new DraggableGroup();
+  divDrag.install(query("#div"));
+  
+  var drop = new DropzoneGroup();
+  drop.installAll(queryAll(".dropzone"));
+  drop.accept.add(svgDrag);
+  drop.accept.add(divDrag);
+}

--- a/test/svg/svg_test.html
+++ b/test/svg/svg_test.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>svg_test</title>
+    <link rel="stylesheet" href="svg.css">
+  </head>
+ 
+  <body>
+    <div>
+      <h2>Draggable SVG</h2>
+      <svg width="100" height="100">
+        <rect id="svgRect" width="100" height="100" fill="red"/>
+      </svg>
+    </div>
+    
+    <div>
+      <h2>Draggable Div</h2>
+      <div id="div" style="width: 100px; height: 100px; background-color: yellow"></div>
+    </div>
+    
+    <div>
+      <h2>Div Dropzone</h2>
+      <div class="dropzone"></div>
+    </div>
+    
+    <div>
+      <h2>Svg Dropzone</h2>
+      <svg width="200" height="100">
+        <rect class="dropzone" width="200" height="100" fill="grey"/>
+      </svg>
+    </div>
+    
+    <script type="application/dart" src="svg_test.dart"></script>
+    <!-- for this next line to work, your pubspec.yaml file must have a dependency on 'browser' -->
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #7.
- Fallback to emulated drag mode if an SVG element is dragged.
- IE9 doesn't include some methods for SVG elements. In these cases, I've had to implement workarounds.
- Adding emulated and non-emulated dropzone behavior. DropzoneGroup doesn't know if an SVG element is being dragged.
- Tests added to `test/svg` folder.
